### PR TITLE
Add option to use selection clipboard on Linux

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -36,6 +36,7 @@
           <p>Audio volume: <input type="range" min="0" max="100" v-model="configJson.audioVolume"></p>
           <p>Debug enabled: <input type="checkbox" v-model="configJson.debugEnabled"></p>
           <p>? button enabled: <input type="checkbox" v-model="configJson.aboutEnabled"></p>
+          <p>Use selection on Linux: <input type="checkbox" v-model="configJson.useSelection"></p>
           <br><p><input type="submit" value="Save" onclick="saveConfig()"></p>
           <br><br><p>You have to restart the app to refresh the frequencies.</p>
           <br><p><input type="submit" value="Export data as JSON" onclick="exportJson(false)"><input type="submit" value="Clear data" onclick="clearEntries()"><input type="submit" value="Open data folder" onclick="openFilePath()"><input type="submit" value="Delete all data" onclick="deleteAllData()"><input type="submit" value="Check for updates" onclick="checkForUpdates()"></p>

--- a/default_config.json
+++ b/default_config.json
@@ -5,5 +5,6 @@
   "updateCheckFrequency": 60,
   "aboutEnabled": true,
   "audioEnabled": false,
-  "audioVolume": 50
+  "audioVolume": 50,
+  "useSelection": false
 }

--- a/src/app.coffee
+++ b/src/app.coffee
@@ -1,7 +1,10 @@
 comparationImage= (image) ->
   return image.toJpeg(0).toString()
 
-currentClipboard = comparationImage(clipboard.readImage())
+selection = null
+if configJson.useSelection
+      selection = 'selection'
+currentClipboard = comparationImage(clipboard.readImage(selection))
 copiedImage = null
 
 clearEntries= ->
@@ -41,34 +44,34 @@ entryList = new Vue(
       if type == 'text'
         if !remote.getCurrentWindow().isFocused()
           clipboardData =
-            content: clipboard.readText()
+            content: clipboard.readText(selection)
             type: 'text'
             timestamp: time
           #console.log("Data is text!")
           #console.log(clipboardData)
-          currentClipboard = clipboard.readText()
+          currentClipboard = clipboard.readText(selection)
           @entries.unshift clipboardData
           playCopyTo()
         else
-          currentClipboard = clipboard.readText()
+          currentClipboard = clipboard.readText(selection)
       else if type == 'image'
-        path = @writeImage(clipboard.readImage().toPng(), time.getFullYear() + '-' + time.getMonth() + 1 + '-' + time.getDate() + ' ' + time.getHours() + '-' + time.getMinutes() + '-' + time.getSeconds() + '-' + time.getMilliseconds())
+        path = @writeImage(clipboard.readImage().toPng(), time.getFullYear() + '-' + time.getMonth() + 1 + '-' + time.getDate() + ' ' + time.getHours() + '-' + time.getMinutes() + '-' + time.getSeconds() + '-' + time.getMilliseconds(selection))
         clipboardData =
           content: path
           type: 'image'
           timestamp: time
-        currentClipboard = comparationImage(clipboard.readImage())
+        currentClipboard = comparationImage(clipboard.readImage(selection))
         #console.log("Data is an image! - " + clipboardData);
         @entries.unshift clipboardData
         playCopyTo()
 
     copyEntry: (entry) ->
       if entry.type == 'text'
-        clipboard.writeText(entry.content)
+        clipboard.writeText(selectionentry.content)
         playCopyFrom()
       if entry.type == 'image'
         img = nativeImage.createFromPath(entry.content)
-        clipboard.writeImage(img)
+        clipboard.writeImage(selectionimg)
         copiedImage = comparationImage(img)
         playCopyFrom()
 
@@ -85,12 +88,12 @@ entryList = new Vue(
 )
 
 checkForClipboardChanges= ->
-  readText = clipboard.readText()
+  readText = clipboard.readText(selection)
   if readText != ''
     if readText!= currentClipboard
       entryList.saveToClipboard('text')
   else
-    readImage = clipboard.readImage()
+    readImage = clipboard.readImage(selection)
     compImage = comparationImage(readImage)
     if compImage != currentClipboard
       if compImage != copiedImage


### PR DESCRIPTION
It's more useful for me to track selection clipboard, so I added option to use [PRIMARY instead of CLIPBOARD](https://en.wikipedia.org/wiki/X_Window_selection#Clipboard). This is likely not done very cleanly (restart required to change) and in any case works only on X-based systems. So not necessarily expecting a merge, but figured it would be nice to share anyway.